### PR TITLE
Remove unnecessary `brew install` command for the `imageoptim` cask

### DIFF
--- a/.github/workflows/pull_request_merge.yml
+++ b/.github/workflows/pull_request_merge.yml
@@ -61,7 +61,6 @@ jobs:
           echo "Found images: $count"
           if [ $count -gt 0 ]; then
             brew update
-            brew install imageoptim
             brew install imageoptim-cli
             imageoptim "${images_array[@]}"
           fi


### PR DESCRIPTION
`imageoptim` is a cask, not a formula, and it installs the ImageOptim desktop application. The `imageoptim` command (used in `imageoptim "${images_array[@]}"`) is installed by `brew install imageoptim-cli` so the `brew install imageoptim` line seems to be unnecessary.

If I am mistaken and there is a valid reason for that line to be there, please simply close this PR.